### PR TITLE
Set IntersectionObserver to not yet shipped for FF

### DIFF
--- a/polyfills/IntersectionObserver/config.json
+++ b/polyfills/IntersectionObserver/config.json
@@ -5,7 +5,7 @@
 		"android": "4.4 - *",
 		"bb": "7 - 10",
 		"chrome": "<51",
-		"firefox": "<52",
+		"firefox": "*",
 		"firefox_mob": "47 - *",
 		"ie": "7 - *",
 		"ie_mob": "11 - *",


### PR DESCRIPTION
Looks like this wasn't actually shipped in FF 52 after all (it's still behind a flag by default)

See:
http://caniuse.com/#search=IntersectionObserver
https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#Browser_compatibility

`new IntersectionObserver(...)` fails in FF 52 with "ReferenceError: IntersectionObserver is not defined" and `https://cdn.polyfill.io/v2/polyfill.min.js?features=IntersectionObserver` returns no Polyfill